### PR TITLE
configure SAML plugin to sign logout requests by default. It's needed…

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -42,6 +42,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
         'idpmetadata'     => '',
         'debug'           => 0,
         'duallogin'       => 1,
+	'customloginpage'       => 1,
         'anyauth'         => 1,
         'idpattr'         => 'uid',
         'mdlattr'         => 'username',
@@ -149,6 +150,21 @@ class auth_plugin_saml2 extends auth_plugin_base {
 
         $this->log(__FUNCTION__ . ' enter');
 
+	// If customlogin page is set and the saml parameter is not 
+        // then dispaly the custom login page
+        $saml = optional_param('saml', NULL , PARAM_BOOL);
+        if ($this->config->customloginpage == 1 && is_null($saml)) {
+           $this->log(__FUNCTION__ . ' displaying custom login page');
+           $PAGE->set_url('/login/index.php');
+           $PAGE->set_heading($SITE->fullname);
+           echo $OUTPUT->header();
+           include($CFG->dirroot.'/auth/saml2/saml2_form.html');
+           echo $OUTPUT->footer();
+           exit();
+        }
+
+
+
         $saml = optional_param('saml', 0, PARAM_BOOL);
 
         // If dual auth then stop and show login page.
@@ -160,7 +176,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
         // If ?saml=on even when duallogin is on, go directly to IdP.
         if ($saml == 1) {
             $this->log(__FUNCTION__ . ' skipping due to query param ?saml=on');
-            return;
+            //return; Seems a but to me, should trigger saml auth
         }
 
         // Check whether we've skipped saml already.

--- a/config/authsources.php
+++ b/config/authsources.php
@@ -41,6 +41,7 @@ $config = array(
         'privatekey' => $saml2auth->spname . '.pem',
         'privatekey_pass' => get_site_identifier(),
         'certificate' => $saml2auth->spname . '.crt',
+	'sign.logout' => true,
     ),
 );
 

--- a/lang/en/auth_saml2.php
+++ b/lang/en/auth_saml2.php
@@ -44,6 +44,10 @@ $string['duallogin_help'] = '
 <p>If off, then admins can still see the manual login page via /login/index.php?saml=off</p>
 <p>If on, then external pages can deep link into moodle using saml eg /course/view.php?id=45&saml=on</p>
 ';
+$string['customloginpage'] = 'Display a custom login page';
+$string['customloginpage_help'] = '
+<p>If on displays a custom simplified login page where users can choose to proceed to the IdP or to the classic login page. This is sometime needed when user gets confused by a login page where login/password fields are displayed</p>
+';
 $string['anyauth'] = 'Allowed any auth type';
 $string['anyauth_help'] = 'Yes: Allow SAML login for all users? No: Only users who have saml2 as their type.';
 $string['wrongauth'] = 'You have logged in succesfully as \'{$a}\' but are not authorized to access Moodle.';
@@ -73,4 +77,5 @@ $string['requireint'] = 'This field is required and needs to be a positive integ
 $string['regenerate_submit'] = 'Regenerate';
 $string['test_passive'] = '<a href="{$a}">Test using isPassive</a>';
 $string['test_auth'] = '<a href="{$a}">Test isAuthenticated and login</a>';
-
+$string['accesssaml'] = 'Login with your institution credentials';
+$string['accessnosaml'] = 'Login with local moodle credentials';

--- a/saml2_form.html
+++ b/saml2_form.html
@@ -1,0 +1,11 @@
+<div class="loginbox clearfix">
+<div class="loginpanel">
+<div>
+<a href="<?php echo get_login_url() . '?saml=on';?>"><?php print_string('accesssaml', 'auth_saml2');?></a>
+</div>
+<br/>
+<div>
+<a href="<?php echo get_login_url() . '?saml=off';?>"><?php print_string('accessnosaml', 'auth_saml2');?></a>
+</div>
+</div>
+</div>


### PR DESCRIPTION
Hello,

I added the parameter:

sign.logout' => true, 

in config/authsources.php

This is requested by some IdP like ADFS to be able to process logouts.