### PR TITLE
configure SAML plugin to sign logout requests by default.

### DIFF
--- a/config/authsources.php
+++ b/config/authsources.php
@@ -41,6 +41,7 @@ $config = array(
         'privatekey' => $saml2auth->spname . '.pem',
         'privatekey_pass' => get_site_identifier(),
         'certificate' => $saml2auth->spname . '.crt',
+	'sign.logout' => true,
     ),
 );
 

--- a/config/authsources.php
+++ b/config/authsources.php
@@ -41,7 +41,7 @@ $config = array(
         'privatekey' => $saml2auth->spname . '.pem',
         'privatekey_pass' => get_site_identifier(),
         'certificate' => $saml2auth->spname . '.crt',
-	'sign.logout' => true,
+        'sign.logout' => true,
     ),
 );
 


### PR DESCRIPTION
Configure SAML plugin to sign logout requests by default's needed by some IdP like ADFS