### PR TITLE
Issue#23 field locking - Redux

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -61,7 +61,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
         $this->certdir = "$CFG->dataroot/saml2/";
         $this->certpem = $this->certdir . $this->spname . '.pem';
         $this->certcrt = $this->certdir . $this->spname . '.crt';
-        $this->config = (object) array_merge($this->defaults, (array) get_config('auth_saml2') );
+        $this->config = (object) array_merge($this->defaults, (array) get_config('auth/saml2') );
     }
 
     /**
@@ -420,7 +420,7 @@ class auth_plugin_saml2 extends auth_plugin_base {
 
         foreach ($this->defaults as $key => $value) {
             if ($config->$key != $this->config->$key) {
-                set_config($key, $config->$key, 'auth_saml2');
+                set_config($key, $config->$key, 'auth/saml2');
                 $haschanged = true;
             }
         }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -74,20 +74,19 @@ function xmldb_auth_saml2_upgrade($oldversion) {
 
     if ($oldversion < 2016080302) {
         // Update plugin configuration settings from auth_saml2 to auth/saml2.
-        $current_config = get_config('auth_saml2');
-
+        $currentconfig = get_config('auth_saml2');
 
         // Remove old config.
         $rs = $DB->get_recordset_select('config_plugins', 'plugin = ?', array('auth_saml2'));
         foreach ($rs as $record) {
-            if ($record->name != 'version'){
+            if ($record->name != 'version') {
                 $DB->delete_records('config_plugins', array('id' => $record->id));
             }
         }
         $rs->close();
 
         // Set new config.
-        foreach ($current_config as $key => $value) {
+        foreach ($currentconfig as $key => $value) {
             set_config($key, $value, 'auth/saml2');
         }
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -72,16 +72,27 @@ function xmldb_auth_saml2_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2016031701, 'auth', 'saml2');
     }
 
-    if ($oldversion < 2016071201) {
-        // Update plugin configuration settings from auth_saml2 to auth/saml2
+    if ($oldversion < 2016080302) {
+        // Update plugin configuration settings from auth_saml2 to auth/saml2.
+        $current_config = get_config('auth_saml2');
+
+
+        // Remove old config.
         $rs = $DB->get_recordset_select('config_plugins', 'plugin = ?', array('auth_saml2'));
         foreach ($rs as $record) {
-            $record->plugin = 'auth/saml2';
-            $DB->update_record('config_plugins', $record);
+            if ($record->name != 'version'){
+                $DB->delete_records('config_plugins', array('id' => $record->id));
+            }
         }
         $rs->close();
+
+        // Set new config.
+        foreach ($current_config as $key => $value) {
+            set_config($key, $value, 'auth/saml2');
+        }
+
         // Saml2 savepoint reached.
-        upgrade_plugin_savepoint(true, 2016071201, 'auth', 'saml2');
+        upgrade_plugin_savepoint(true, 2016080302, 'auth', 'saml2');
     }
 
     return true;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -72,6 +72,18 @@ function xmldb_auth_saml2_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2016031701, 'auth', 'saml2');
     }
 
+    if ($oldversion < 2016071201) {
+        // Update plugin configuration settings from auth_saml2 to auth/saml2
+        $rs = $DB->get_recordset_select('config_plugins', 'plugin = ?', array('auth_saml2'));
+        foreach ($rs as $record) {
+            $record->plugin = 'auth/saml2';
+            $DB->update_record('config_plugins', $record);
+        }
+        $rs->close();
+        // Saml2 savepoint reached.
+        upgrade_plugin_savepoint(true, 2016071201, 'auth', 'saml2');
+    }
+
     return true;
 }
 

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2016071201;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2016080302;    // The current plugin version (Date: YYYYMMDDXX).
 $plugin->release   = 2016071200;    // Match release exactly to version.
 $plugin->requires  = 2014050800;    // Requires this Moodle version.
 $plugin->component = 'auth_saml2';  // Full name of the plugin (used for diagnostics).

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2016071200;    // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2016071201;    // The current plugin version (Date: YYYYMMDDXX).
 $plugin->release   = 2016071200;    // Match release exactly to version.
 $plugin->requires  = 2014050800;    // Requires this Moodle version.
 $plugin->component = 'auth_saml2';  // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
Initial fix for this issue broke idp integration as the array merge overwrote required values.
I've tested this new fix against a live system and everything behaves as it should.

I'm still not happy with the way this problem is solved. I had a serious go of trying to do it a better way by implementing it at the configuration stages. But authlib is old school.  I couldn't figure out how to do it with refactoring lots of core authlib.